### PR TITLE
Add #:clx-cursor as a dependency to #:clx-cursor-test

### DIFF
--- a/clx-cursor.asd
+++ b/clx-cursor.asd
@@ -18,7 +18,7 @@
   :author "Michael Filonenko <filonenko.mikhail@gmail.com>"
   :license "MIT"
   :version "0.1"
-  :depends-on (#:clx #:cl-fad)
+  :depends-on (#:clx #:clx-cursor #:cl-fad)
   :components ((:module test
                         :components ((:file "hello-world")))))
 


### PR DESCRIPTION
Should address http://report.quicklisp.org/2018-01-16/failure-report/clx-cursor.html#clx-cursor-test

See http://blog.quicklisp.org/2018/01/build-failures-with-asdf-331.html for further context